### PR TITLE
feat:마지막 발송 이메일 정보 api 추가

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,7 @@ require('dotenv').config();
 
 const http = require('http');
 const debug = require('debug')('server:server');
+
 const app = require('../app');
 const connectDB = require('../database');
 const config = require('../config');

--- a/constants/index.js
+++ b/constants/index.js
@@ -6,6 +6,7 @@ exports.ERROR_MESSAGE = {
   RESTRICTED_MIN_EMAIL_LENGTH: '이메일은 최소 5자 이상 입력해주세요.',
   RESTRICTED_MAX_EMAIL_LENGTH: '이메일은 최대 30자 이하로 입력해주세요.',
   RESTRICTED_MAX_PASSWORD_LENGTH: '비밀번호는 최소 8자 이상 입력해주세요.',
+  INVALID_USER_ID: '잘못된 유저 아이디입니다.',
   INVALID_EMAIL_FORM:
     '이메일 형식을 지켜주세요, example@service.com 형식으로 입력해주세요',
 };

--- a/database/index.js
+++ b/database/index.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+
 const config = require('../config');
 
 module.exports = async function connectDB() {

--- a/loaders/middleware.js
+++ b/loaders/middleware.js
@@ -3,6 +3,7 @@ const logger = require('morgan');
 const cookieParser = require('cookie-parser');
 const session = require('express-session');
 const passport = require('passport');
+
 const { cookieSecret } = require('../config');
 
 module.exports = app => {

--- a/loaders/router.js
+++ b/loaders/router.js
@@ -1,5 +1,7 @@
 const index = require('../routes/index');
+const users = require('../routes/users');
 
 module.exports = app => {
   app.use('/', index);
+  app.use('/users', users);
 };

--- a/models/EmailTemplate.js
+++ b/models/EmailTemplate.js
@@ -39,6 +39,12 @@ const emailTemplateSchema = new mongoose.Schema(
         },
       },
     ],
+    totalSendCount: {
+      type: Number,
+    },
+    successSendCount: {
+      type: Number,
+    },
     startSendDate: {
       type: Date,
     },

--- a/models/User.js
+++ b/models/User.js
@@ -1,5 +1,27 @@
 const mongoose = require('mongoose');
+
 const ERROR_MESSAGES = require('../constants');
+
+const subscriberSchema = new mongoose.Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    adAgreement: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
 
 const userSchema = new mongoose.Schema(
   {
@@ -33,26 +55,11 @@ const userSchema = new mongoose.Schema(
     contact: {
       type: String,
     },
-    subscribers: [
-      {
-        email: {
-          type: String,
-          required: true,
-        },
-        name: {
-          type: String,
-          required: true,
-        },
-        adAgreement: {
-          type: Boolean,
-          required: true,
-          default: false,
-        },
-      },
-    ],
+    subscribers: [subscriberSchema],
     emailTemplates: [
       {
         type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
       },
     ],
   },

--- a/models/sample-emailTemplate.json
+++ b/models/sample-emailTemplate.json
@@ -1,0 +1,33 @@
+{
+  "_id": {
+    "$oid": "63eb341a27ec5a9a55b9eb29"
+  },
+  "editingStep": 1,
+  "emailTitle": "제목",
+  "emailContent": "본문",
+  "sender": "발신자",
+  "emailPreviewText": "미리보기",
+  "recipients": [],
+  "totalSendCount": 1,
+  "successSendCount": 1,
+  "startSendDate": {
+    "$date": {
+      "$numberLong": "1676292302455"
+    }
+  },
+  "endSendDate": {
+    "$date": {
+      "$numberLong": "1676292302455"
+    }
+  },
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1676292302455"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1676292302455"
+    }
+  }
+}

--- a/models/sample-user.json
+++ b/models/sample-user.json
@@ -1,0 +1,28 @@
+{
+  "_id": {
+    "$oid": "63ea30ce46afe9b7b0cc602a"
+  },
+  "email": "test@test.com",
+  "password": "$2a$10$sFwX.AsJdoMGwFK2EYD.tu6PUBSDt.rp5XvAej49.DCEqa/rpVkqG",
+  "userName": "test",
+  "cdnCode": "cdn코드",
+  "companyName": "회사명",
+  "address": "주소",
+  "contact": "연락처",
+  "emailTemplates": [
+    {
+      "$oid": "63eb341a27ec5a9a55b9eb29"
+    }
+  ],
+  "subscribers": [],
+  "createdAt": {
+    "$date": {
+      "$numberLong": "1676292302455"
+    }
+  },
+  "updatedAt": {
+    "$date": {
+      "$numberLong": "1676292302455"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "server",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "server",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/passport/index.js
+++ b/passport/index.js
@@ -1,5 +1,6 @@
 const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
+
 const User = require('../models/User');
 const { verifyUser } = require('../services/auth.service');
 const { ERROR_MESSAGE } = require('../constants');

--- a/routes/controllers/auth.controller.js
+++ b/routes/controllers/auth.controller.js
@@ -1,4 +1,5 @@
 const passport = require('passport');
+
 const { createUser } = require('../../services/auth.service');
 
 exports.signUp = async function (req, res, next) {
@@ -6,7 +7,7 @@ exports.signUp = async function (req, res, next) {
     const userDTO = req.body;
     await createUser(userDTO, next);
 
-    res.status(201).json('회원가입 완료');
+    res.status(201).json();
   } catch (error) {
     next(error);
   }

--- a/routes/controllers/user.controller.js
+++ b/routes/controllers/user.controller.js
@@ -1,0 +1,16 @@
+const userService = require('../../services/user.service');
+
+exports.getLastSentEmailTemplate = async function (req, res, next) {
+  try {
+    const { user_id: userId } = req.params;
+
+    const lastSentEmailTemplate = await userService.getLastSentEmailTemplate(
+      userId,
+      next,
+    );
+
+    res.json(lastSentEmailTemplate);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+
 const { signUp, login } = require('./controllers/auth.controller');
 
 const router = express.Router();

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,10 +1,9 @@
 const express = require('express');
 
+const { getLastSentEmailTemplate } = require('./controllers/user.controller');
+
 const router = express.Router();
 
-/* GET users listing. */
-router.get('/', function (req, res) {
-  res.send('respond with a resource');
-});
+router.get('/:user_id/email-templates', getLastSentEmailTemplate);
 
 module.exports = router;

--- a/services/auth.service.js
+++ b/services/auth.service.js
@@ -1,4 +1,5 @@
 const bcrypt = require('bcryptjs');
+
 const User = require('../models/User');
 const { ERROR_MESSAGE } = require('../constants');
 const { saltRound } = require('../config');
@@ -11,7 +12,7 @@ exports.createUser = async ({ email, password, userName, next }) => {
     }
 
     const cdnCode = 'test'; // 임시코드
-    const salt = await bcrypt.genSalt(saltRound);
+    const salt = await bcrypt.genSalt(Number(saltRound));
     const hashedPassword = await bcrypt.hash(password, salt);
 
     await User.create({ email, password: hashedPassword, userName, cdnCode });

--- a/services/user.service.js
+++ b/services/user.service.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+
+const EmailTemplate = require('../models/EmailTemplate');
+const User = require('../models/User');
+const { INVALID_USER_ID } = require('../constants');
+
+exports.getLastSentEmailTemplate = async (userId, next) => {
+  try {
+    if (!mongoose.isValidObjectId(userId)) {
+      return next({ status: 400, message: INVALID_USER_ID });
+    }
+
+    const user = await User.findById(userId).lean();
+    const emailTemplates = await EmailTemplate.find({
+      _id: { $in: user.emailTemplates },
+    });
+    const lastSentEmailTemplate =
+      emailTemplates.length > 0
+        ? emailTemplates.reduce((prev, current) => {
+            return prev.endSendDate >= current.endSendDate ? prev : current;
+          })
+        : null;
+
+    return lastSentEmailTemplate;
+  } catch (error) {
+    next(error);
+  }
+};


### PR DESCRIPTION
### 주요 구현사항
유저ID로 User테이블의 이메일 템플릿 리스트(_id값)를 먼저 찾고, 그 템플릿들을 다시 EmailTemplate테이블에서 조회하는 로직입니다. 
배열을 파라미터로 조회하는법을 찾느라 시간이 좀 걸렸습니다. https://www.mongodb.com/docs/manual/reference/operator/query/in/

### 기타 수정 및 추가내역
1. .env에서 가져오는 saltRound값은 number형태가 아니여서 bcrypt.gensalt(saltRound)했을때 에러가 발생하는걸 발견해서 Number로 감싸주었습니다. 
2. 회의한 내용대로 import시 외부모듈과 내부모듈사이에 개행으로 구분을 했습니다.
3. database sample.json을 추가했습니다. 
4. 회의한 내용대로 subscriber를 subschema로 추가했습니다.
5. 빠진 schema들을 추가했습니다.