### PR TITLE
feat: 새로운 이메일 탬플릿 생성 api 추가 및 파일구조 조금 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   },
   "extends": ["airbnb", "plugin:prettier/recommended"],
   "rules": {
-    "consistent-return": "warn"
+    "consistent-return": "warn",
+    "no-underscore-dangle": "off"
   },
   "parserOptions": {
     "ecmaVersion": 2022

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run pre-commit
+npm run pre-commit

--- a/models/EmailTemplate.js
+++ b/models/EmailTemplate.js
@@ -3,20 +3,24 @@ const mongoose = require('mongoose');
 const emailTemplateSchema = new mongoose.Schema(
   {
     editingStep: {
-      type: Number,
-      required: true,
+      type: String,
+      default: '01',
     },
     emailTitle: {
       type: String,
+      default: '제목없음',
     },
     emailContent: {
       type: String,
+      default: '',
     },
     sender: {
       type: String,
+      required: true,
     },
     emailPreviewText: {
       type: String,
+      default: '',
     },
     recipients: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "cookie-parser": "~1.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/routes/controllers/emailTemplate.controller.js
+++ b/routes/controllers/emailTemplate.controller.js
@@ -1,0 +1,15 @@
+const { createNewEmailTemplate } = require('../../services/emailTemplate');
+const { getUserName } = require('../../services/user.service');
+
+exports.createNewEmailTemplate = async function (req, res, next) {
+  try {
+    const userName = await getUserName(req.params.user_id);
+    const newEmailTemplate = await createNewEmailTemplate(userName);
+
+    res.status(201).json({
+      emailTemplateId: String(newEmailTemplate._id),
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,10 +4,15 @@ const {
   getEmailTemplates,
   getSubscribersTrend,
 } = require('./controllers/user.controller');
+const {
+  createNewEmailTemplate,
+} = require('./controllers/emailTemplate.controller');
 
 const router = express.Router();
 
 router.get('/:user_id/email-templates', getEmailTemplates);
+
+router.post('/:user_id/email-templates', createNewEmailTemplate);
 
 router.get('/:user_id/subscribers/trend', getSubscribersTrend);
 

--- a/services/auth.service.js
+++ b/services/auth.service.js
@@ -4,7 +4,7 @@ const User = require('../models/User');
 const { ERROR_MESSAGE } = require('../constants');
 const { saltRound } = require('../config');
 
-exports.createUser = async ({ email, password, userName, next }) => {
+exports.createUser = async ({ email, password, userName }, next) => {
   try {
     const user = await User.findOne({ email }).lean();
     if (user) {

--- a/services/emailTemplate.js
+++ b/services/emailTemplate.js
@@ -1,0 +1,11 @@
+const EmailTemplate = require('../models/EmailTemplate');
+
+exports.createNewEmailTemplate = async function (userName) {
+  const newEmailTemplate = {
+    sender: userName,
+  };
+
+  const result = await EmailTemplate.create(newEmailTemplate);
+
+  return result;
+};

--- a/services/user.service.js
+++ b/services/user.service.js
@@ -102,3 +102,9 @@ exports.getSubscribersTrend = async (userId, next) => {
     next(error);
   }
 };
+
+exports.getUserName = async function (userId) {
+  const user = await User.findById(userId).lean();
+
+  return user.userName;
+};


### PR DESCRIPTION
## 주요 구현 사항
1. 이메일 탬플릿 생성 api 추가 완료 했습니다.
2. 기존의 정진님 코드 파일구조가 살짝 헷갈리는 부분들이 있어 허들로 말씀 드렸고 새롭게 쓰일 파일구조를 적용했습니다.
3. 서비스는 기본적으로 user 독에 접근하면 user.js 로 emailTemplate 독에 접근하면 emailTemplate.js 에 로직을 추가하면 됩니다.
4. 서버 쪽에서 이메일탬플릿을 생성하고 id 를 보내주는 식으로 진행하기로해서 emailTemplate 모델의 일부 초기값들을 수정했습니다.
5. 나중에 프론트에서 데이터 다룰때 더 편할 거 같아 emailTemplate 스키마에서 스텝 부분을 숫자에서 문자열로 바꿨습니다.
## 기타
1. 기능 구현 자체는 어려운 사항이 딱히 없없고 내 코드가 아닌 협업하는 팀원의 코드 구조를 처음 접해봐서 전체적인 구조를 파악하는게 조금 시간이 걸렸습니다.