### PR TITLE
feat: 이메일 수정 요청 api 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run pre-commit
-npm run pre-commit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/routes/controllers/emailTemplate.controller.js
+++ b/routes/controllers/emailTemplate.controller.js
@@ -1,6 +1,7 @@
 const {
   createNewEmailTemplate,
   getEmailTemplateByEmailId,
+  updateEmailTemplate,
 } = require('../../services/emailTemplate.service');
 const { getUserName } = require('../../services/user.service');
 
@@ -24,6 +25,16 @@ exports.getEditingOrCompleteEmailTemplate = async function (req, res, next) {
     );
 
     res.json(emailTemplate);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.editEmailTemplate = async function (req, res, next) {
+  try {
+    await updateEmailTemplate(req.params.email_template_id, req.body);
+
+    res.sendStatus(200);
   } catch (err) {
     next(err);
   }

--- a/routes/users.js
+++ b/routes/users.js
@@ -7,6 +7,7 @@ const {
 const {
   createNewEmailTemplate,
   getEditingOrCompleteEmailTemplate,
+  editEmailTemplate,
 } = require('./controllers/emailTemplate.controller');
 
 const router = express.Router();
@@ -15,6 +16,8 @@ router.get(
   '/:user_id/email-templates/:email_template_id',
   getEditingOrCompleteEmailTemplate,
 );
+
+router.patch('/:user_id/email-templates/:email_template_id', editEmailTemplate);
 
 router.get('/:user_id/email-templates', getEmailTemplates);
 

--- a/services/emailTemplate.service.js
+++ b/services/emailTemplate.service.js
@@ -15,3 +15,7 @@ exports.getEmailTemplateByEmailId = async function (emailId) {
 
   return emailTemplate;
 };
+
+exports.updateEmailTemplate = async function (emailId, update) {
+  await EmailTemplate.findByIdAndUpdate(emailId, update);
+};


### PR DESCRIPTION
## 변경사항
1. 이메일 편집 단계에 따라 이메일 수정내용을 patch 해주는 api 를 추가했습니다.
2. pre-commit 에 npm run pre-commit 메시지가 두개가 있어 하나를 삭제했습니다.

## 의논사항
1. userService 모듈을 한번에 불러오지 말고 필요한 메서드들만 불러오는게 좋을 것 같습니다.
2. 어떤 곳은 화살표 함수를 쓰셨다가 어떤곳은 함수 선언을 쓰셨다가 하시는 등 정진님 코드 자체의 컨벤션이 일정하지 않은 부분들이 많은데 통일되도록 신경써주시면 좋을 것 같습니다.