### PR TITLE
fix: 최근 발송 이메일 요청 로직 버그 수정 및 리팩토링

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,5 @@
   "rules": {
     "consistent-return": "warn",
     "no-underscore-dangle": "off"
-  },
-  "parserOptions": {
-    "ecmaVersion": 2022
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/routes/controllers/emailTemplate.controller.js
+++ b/routes/controllers/emailTemplate.controller.js
@@ -15,7 +15,7 @@ exports.getEmailTemplates = async function (req, res, next) {
   try {
     const targetUser = await getTargetUser(req.params.user_id);
 
-    if (req.query?.send_date === 'last') {
+    if (req.query.send_date === 'last' && req.query.count === '1') {
       const lastSentEmailTemplate = await getLastSentEmailTemplate(targetUser);
 
       return res.json(lastSentEmailTemplate);

--- a/services/emailTemplate.service.js
+++ b/services/emailTemplate.service.js
@@ -21,9 +21,11 @@ exports.getLastSentEmailTemplate = async function (targetUser) {
     _id: { $in: targetUser.emailTemplates },
   }).lean();
 
+  const sendedEmailTemplates = emailTemplates.filter(item => item.endSendDate);
+
   const lastSentEmailTemplate =
-    emailTemplates.length > 0
-      ? emailTemplates.reduce((prev, current) => {
+    sendedEmailTemplates.length > 0
+      ? sendedEmailTemplates.reduce((prev, current) => {
           return prev.endSendDate >= current.endSendDate ? prev : current;
         })
       : null;


### PR DESCRIPTION
## 변경사항

1. 발송하지 않은 이메일이 응답으로 오는 버그가 있어 filter 메서드를 추가하여 수정했습니다.
2. 옵셔널 체이닝 연산자가 필요 없어 보여 삭제한 후 eslint 설정에서도 삭제했습니다.
3. 우리가 정해놓은 엔드포인트인 `/users/:user_id/email-templates?send_date=last&count=1` 에만 응답하기 위해 `req.query.count === '1'` 조건도 추가해줬습니다.