### PR TITLE
feat: 이메일 삭제 api 추가

### DIFF
--- a/routes/controllers/emailTemplate.controller.js
+++ b/routes/controllers/emailTemplate.controller.js
@@ -4,11 +4,13 @@ const {
   getEmailTemplate,
   getEmailTemplates,
   updateEmailTemplate,
+  deleteEmailTemplate,
 } = require('../../services/emailTemplate.service');
 const {
   getUserName,
   addEmailIdToUser,
   findUserByUserId,
+  updateEmailIdToUser,
 } = require('../../services/user.service');
 
 exports.getEmailTemplates = async function (req, res, next) {
@@ -56,6 +58,18 @@ exports.getEditingOrCompleteEmailTemplate = async function (req, res, next) {
 exports.editEmailTemplate = async function (req, res, next) {
   try {
     await updateEmailTemplate(req.params.email_template_id, req.body);
+
+    res.sendStatus(200);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteEmailTemplate = async function (req, res, next) {
+  try {
+    await deleteEmailTemplate(req.params.email_template_id);
+
+    await updateEmailIdToUser(req.params.user_id, req.params.email_template_id);
 
     res.sendStatus(200);
   } catch (err) {

--- a/routes/users.js
+++ b/routes/users.js
@@ -11,6 +11,7 @@ const {
   createNewEmailTemplate,
   getEditingOrCompleteEmailTemplate,
   editEmailTemplate,
+  deleteEmailTemplate,
 } = require('./controllers/emailTemplate.controller');
 const {
   getUserSendingInfo,
@@ -25,6 +26,11 @@ router.get(
 );
 
 router.patch('/:user_id/email-templates/:email_template_id', editEmailTemplate);
+
+router.delete(
+  '/:user_id/email-templates/:email_template_id',
+  deleteEmailTemplate,
+);
 
 router.get('/:user_id/email-templates', getEmailTemplates);
 

--- a/services/emailTemplate.service.js
+++ b/services/emailTemplate.service.js
@@ -44,3 +44,7 @@ exports.getEmailTemplates = async function (targetUser) {
 exports.updateEmailTemplate = async function (emailId, update) {
   await EmailTemplate.findByIdAndUpdate(emailId, update);
 };
+
+exports.deleteEmailTemplate = async function (emailId) {
+  await EmailTemplate.deleteOne({ _id: emailId });
+};

--- a/services/user.service.js
+++ b/services/user.service.js
@@ -112,3 +112,7 @@ exports.getUserSendingInfo = async function (userId) {
 exports.updateUserSendingInfo = async function (userId, update) {
   await User.findByIdAndUpdate(userId, update);
 };
+
+exports.updateEmailIdToUser = async function (userId, emailId) {
+  await User.updateOne({ _id: userId }, { $pull: { emailTemplates: emailId } });
+};


### PR DESCRIPTION
이메일 삭제 API 추가하였습니다.
해당 이메일ID가 이메일 템플릿에서 삭제되고, User의 EmailTemplates 필드에서도 삭제됩니다.
이메일 생성 API에서는 양쪽 둘다 추가되는로직 확인되어서 따로 추가 안했습니다.